### PR TITLE
Add `estragon.yaml` config parsing package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v1.0.0-rc.1
     hooks:
       - id: go-mod-tidy-repo
-      - id: go-test-pkg
-      - id: go-vet-pkg
+      - id: go-test-mod
+      - id: go-vet-mod
       - id: go-fmt
         args: ["-s", "-w"]

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,187 @@
+package config
+
+import (
+	"errors"
+
+	"github.com/aus-hawk/estragon/env"
+	"gopkg.in/yaml.v3"
+)
+
+type schema struct {
+	Common       common `yaml:",inline"`
+	Environments map[string]common
+	Packages     map[string]map[string][]string
+	Dots         map[string]dot
+}
+
+type dot struct {
+	Common       common `yaml:",inline"`
+	Environments map[string]common
+	Rules        map[string]map[string]string
+	Packages     map[string]string
+}
+
+type common struct {
+	Method    string
+	Root      string
+	DotPrefix *bool `yaml:"dot-prefix,omitempty"`
+}
+
+type EnvSelector interface {
+	Select(keys []string) (key string, fields []string)
+}
+
+// A Config contains all of the information about how files and packages are
+// installed.
+type Config struct {
+	schema   schema
+	selector EnvSelector
+}
+
+// NewConfig creates a config based on the contents of the YAML content `in`,
+// and the Environment `e`. If something goes wrong parsing `in`, err is
+// non-nil.
+func NewConfig(in []byte, s EnvSelector) (c Config, err error) {
+	err = yaml.Unmarshal(in, &c.schema)
+	c.selector = s
+	return
+}
+
+// A Package represents a single key-value pair in the package map of a dot. The
+// Name is the key of a package a dot is using. The Desc is the description of
+// the purpose the specified package serves for the dot. The List is the list of
+// expanded package names if the package is specified in the global package map.
+type Package struct {
+	Name string
+	Desc string
+	List []string
+}
+
+// Packages gets a dot `dotName`'s list of packages and their associated
+// expansions as a slice. If the dot specified does not exist, a non-nil error
+// will be the second returned value.
+func (c Config) Packages(dotName string) ([]Package, error) {
+	dot, ok := c.schema.Dots[dotName]
+	if !ok {
+		return nil, errors.New("Dot " + dotName + " not in config")
+	}
+
+	packages := make([]Package, 0, len(dot.Packages))
+	for name, desc := range dot.Packages {
+		pkg := Package{
+			Name: name,
+			Desc: desc,
+			List: c.expandPackage(name),
+		}
+		packages = append(packages, pkg)
+	}
+
+	return packages, nil
+}
+
+func (c Config) expandPackage(pkgName string) []string {
+	packages, ok := c.schema.Packages[pkgName]
+	if !ok {
+		// The package is not expanded in any way.
+		return []string{pkgName}
+	}
+
+	key, fields := c.selector.Select(mapKeys(packages))
+
+	pkgList, ok := packages[key]
+	if !ok {
+		// The package is not expanded under the current environment.
+		return []string{pkgName}
+	}
+
+	match := env.NewMatch(key, fields)
+	realPkgs := make([]string, 0, len(pkgList))
+	for _, pkg := range pkgList {
+		realPkg := match.Replace(pkg)
+		realPkgs = append(realPkgs, realPkg)
+	}
+
+	return realPkgs
+}
+
+// A DotConfig holds the most specific settings that can be applied to the
+// installation of dotfiles as specified by a dot configuration in the config.
+// The Rules are set according to the configuration and the environment, and are
+// exclusive to the dot it is a config of. The Method, Root, and DotPrefix are
+// values that can be set in multiple places, with the more specific
+// configurations taking precedence over the more general ones.
+//
+// From specific to general: environment settings within the dot config, the
+// values of the dot config itself, the environment settings of the global
+// config, the values of the global config itself.
+type DotConfig struct {
+	Method       string
+	Root         string
+	DotPrefix    bool
+	dotPrefixSet bool
+	Rules        map[string]string
+}
+
+// Get the DotConfig associated with a specific dot. If the dot does not exist
+// in the config, a non-nil error is the second returned value.
+func (c Config) DotConfig(dotName string) (d DotConfig, err error) {
+	dot, ok := c.schema.Dots[dotName]
+	if !ok {
+		return d, errors.New("Dot " + dotName + " not in config")
+	}
+
+	// Rules are only set in one place.
+	key, _ := c.selector.Select(mapKeys(dot.Rules))
+	envRules, ok := dot.Rules[key]
+	if ok {
+		d.Rules = envRules
+	}
+
+	// Apply common config from dot-specific environment settings.
+	key, _ = c.selector.Select(mapKeys(dot.Environments))
+	commonConf, ok := dot.Environments[key]
+	if ok {
+		d = applyCommonDotConfig(commonConf, d)
+	}
+
+	// Apply common config from dot settings.
+	d = applyCommonDotConfig(dot.Common, d)
+
+	// Apply common config from environment-specific global settings.
+	key, _ = c.selector.Select(mapKeys(c.schema.Environments))
+	commonConf, ok = c.schema.Environments[key]
+	if ok {
+		d = applyCommonDotConfig(commonConf, d)
+	}
+
+	// Apply common config from global settings.
+	d = applyCommonDotConfig(c.schema.Common, d)
+
+	if !d.dotPrefixSet {
+		d.DotPrefix = true
+	}
+
+	return d, nil
+}
+
+func applyCommonDotConfig(c common, d DotConfig) DotConfig {
+	if d.Method == "" {
+		d.Method = c.Method
+	}
+	if d.Root == "" {
+		d.Root = c.Root
+	}
+	if !d.dotPrefixSet && c.DotPrefix != nil {
+		d.DotPrefix = *c.DotPrefix
+		d.dotPrefixSet = true
+	}
+	return d
+}
+
+func mapKeys[K comparable, V any](m map[K]V) []K {
+	ks := make([]K, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,254 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+const goodYaml = `
+method: deep
+root: xdg
+
+environments:
+  test:
+    method: shallow
+    root: home
+    dot-prefix: false
+
+packages:
+  foo:
+    test(s?): ["bar$1", baz]
+
+dots:
+  dotfile:
+    method: copy
+    root: "/test/dir/:"
+    rules:
+      test:
+        "dir/file": "/new/loc/file"
+    packages:
+      foo: "For tests"
+  commonless:
+    packages:
+      quux: "I don't know but it sounds important"
+`
+
+var goodSchema = schema{
+	Common: common{
+		Method: "deep",
+		Root:   "xdg",
+	},
+	Environments: map[string]common{
+		"test": {
+			Method:    "shallow",
+			Root:      "home",
+			DotPrefix: new(bool),
+		},
+	},
+	Packages: map[string]map[string][]string{
+		"foo": {
+			"test(s?)": {"bar$1", "baz"},
+		},
+	},
+	Dots: map[string]dot{
+		"dotfile": {
+			Common: common{
+				Method: "copy",
+				Root:   "/test/dir/:",
+			},
+			Rules: map[string]map[string]string{
+				"test": {
+					"dir/file": "/new/loc/file",
+				},
+			},
+			Packages: map[string]string{
+				"foo": "For tests",
+			},
+		},
+		"commonless": {
+			Packages: map[string]string{
+				"quux": "I don't know but it sounds important",
+			},
+		},
+	},
+}
+
+type mockEnvSelector struct {
+	key    string
+	fields []string
+}
+
+func (s mockEnvSelector) Select(keys []string) (key string, fields []string) {
+	return s.key, s.fields
+}
+
+func TestNewConfig(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   string
+		c    Config
+		err  bool
+	}{
+		{"Bad YAML", "]", Config{}, true},
+		{
+			"Good YAML",
+			goodYaml,
+			Config{
+				schema:   goodSchema,
+				selector: mockEnvSelector{},
+			},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			c, err := NewConfig([]byte(test.in), mockEnvSelector{})
+
+			if err != nil && !test.err {
+				t.Fatal("expected err to be nil, was non-nil")
+			} else if err == nil && test.err {
+				t.Fatal("expected err to be non-nil, was nil")
+			} else if err != nil {
+				// Don't compare invalid configs.
+				return
+			}
+
+			if !reflect.DeepEqual(test.c, c) {
+				t.Errorf(
+					"expected config to be %#v, got %#v",
+					test.c,
+					c,
+				)
+			}
+		})
+	}
+}
+
+func TestPackagesRealDotfile(t *testing.T) {
+	tests := []struct {
+		desc    string
+		env     mockEnvSelector
+		pkgList []Package
+	}{
+		{
+			"Regexp empty",
+			mockEnvSelector{"test(s?)", []string{"test"}},
+			[]Package{
+				{"foo", "For tests", []string{"bar", "baz"}},
+			},
+		},
+		{
+			`Regexp with "s"`,
+			mockEnvSelector{"test(s?)", []string{"tests"}},
+			[]Package{
+				{"foo", "For tests", []string{"bars", "baz"}},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			config := Config{goodSchema, test.env}
+			packages, err := config.Packages("dotfile")
+			if err != nil {
+				t.Fatal("expected err to be nil, got non-nil")
+			}
+			if !reflect.DeepEqual(test.pkgList, packages) {
+				t.Fatalf(
+					"expected package list to be %#v, got %#v",
+					test.pkgList,
+					packages,
+				)
+			}
+
+		})
+	}
+}
+
+func TestPackagesBadDotfile(t *testing.T) {
+	config := Config{goodSchema, mockEnvSelector{}}
+	_, err := config.Packages("not-real-dotfile")
+	if err == nil {
+		t.Fatal("expected err to be non-nil, got nil")
+	}
+}
+
+func TestDotConfigRealDotfile(t *testing.T) {
+	tests := []struct {
+		desc    string
+		env     string
+		dotName string
+		dotConf DotConfig
+	}{
+		{
+			"test env with dotfile dot",
+			"test",
+			"dotfile",
+			DotConfig{
+				Method:       "copy",
+				Root:         "/test/dir/:",
+				DotPrefix:    false,
+				dotPrefixSet: true,
+				Rules: map[string]string{
+					"dir/file": "/new/loc/file",
+				},
+			},
+		},
+		{
+			"No env with dotfile dot",
+			"not matching",
+			"dotfile",
+			DotConfig{
+				Method:       "copy",
+				Root:         "/test/dir/:",
+				DotPrefix:    true,
+				dotPrefixSet: false,
+				Rules:        nil,
+			},
+		},
+		{
+			"test env with commonless dot",
+			"test",
+			"commonless",
+			DotConfig{
+				Method:       "shallow",
+				Root:         "home",
+				DotPrefix:    false,
+				dotPrefixSet: true,
+				Rules:        nil,
+			},
+		},
+		{
+			"No env with commonless dot",
+			"not matching",
+			"commonless",
+			DotConfig{
+				Method:       "deep",
+				Root:         "xdg",
+				DotPrefix:    true,
+				dotPrefixSet: false,
+				Rules:        nil,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			config := Config{
+				goodSchema,
+				mockEnvSelector{test.env, nil},
+			}
+			dotConf, err := config.DotConfig(test.dotName)
+			if err != nil {
+				t.Fatal("expected err to be nil, got non-nil")
+			}
+
+			if !reflect.DeepEqual(test.dotConf, dotConf) {
+				t.Fatalf(
+					"expected dotConf to be %#v, got %#v",
+					test.dotConf,
+					dotConf,
+				)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/aus-hawk/estragon
 
 go 1.20
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
The `.pre-commit-config.yaml` is constantly changing due to it being unclear which hooks need to be run for a modern Go project. Many of the provided hooks exist to cater to projects before the module system.