### PR TITLE
Fix --force not overwriting symlinks

### DIFF
--- a/subcmd/subcmd.go
+++ b/subcmd/subcmd.go
@@ -242,7 +242,9 @@ func (d fileDeployer) ensureOwnership(m map[string]string, dot string) error {
 			return err
 		}
 
-		if d.force && fileExists {
+		_, owned := ownedFiles[file]
+
+		if fileExists && (owned || d.force) {
 			err := os.RemoveAll(file)
 			if err != nil {
 				return err
@@ -250,8 +252,8 @@ func (d fileDeployer) ensureOwnership(m map[string]string, dot string) error {
 			fileExists = false
 		}
 
-		_, owned := ownedFiles[file]
-		if fileExists && !owned {
+		if fileExists {
+			// File should have been deleted if it was owned.
 			return errors.New(
 				file + " exists but is not owned by this directory",
 			)


### PR DESCRIPTION
Copied files could just be truncated and rewritten. With symlinks, the problem was that the function to create a symlink does not overwrite it. Therefore, deleting the files is an easy solution that appeases both methods as copy can just recreate the file and symlink can work like normal.