### PR TITLE
Fix error deploying with non-existent directories

### DIFF
--- a/subcmd/deploy/deploy.go
+++ b/subcmd/deploy/deploy.go
@@ -44,9 +44,10 @@ func NewDotfileDeployer(
 // Deploy either copies or creates links of files within the dot file tree
 // outside of that file tree. It also runs all of the deploy commands. dot is
 // the name of the dot that is being deployed. files is a slice of all of the
-// files (not including directories) within the dot directory. dry determines if
-// an action is actually performed (true) or if it will just be simulated by
-// printing out what would actually happen (false).
+// files (not including directories) within the dot directory. An empty slice
+// represents an empty directory, and a nil one represents a non-existent
+// directory. dry determines if an action is actually performed (true) or if it
+// will just be simulated by printing out what would actually happen (false).
 func (d DotfileDeployer) Deploy(dot string, files []string, dry bool) error {
 	err := d.deployFiles(dot, files, dry)
 	if err != nil {
@@ -67,7 +68,11 @@ func (d DotfileDeployer) deployFiles(dot string, files []string, dry bool) error
 	case "deep", "copy":
 		fileMap = d.deepCopyResolve(dotConf, files, dot)
 	case "shallow":
-		fileMap = d.shallowResolve(dotConf, files, dot)
+		if files != nil {
+			// nil files means the directory doesn't exist and we
+			// shouldn't link to a non-existent directory.
+			fileMap = d.shallowResolve(dotConf, files, dot)
+		}
 	default:
 		if method != "none" {
 			return errors.New(method + " is not a valid method")

--- a/subcmd/subcmd.go
+++ b/subcmd/subcmd.go
@@ -116,9 +116,17 @@ func (s SubcmdRunner) deploySubcmd(dots []string) error {
 }
 
 func (s SubcmdRunner) dirFiles(dot string) ([]string, error) {
-	files := make([]string, 0)
-
 	dotDir := filepath.Join(s.dir, dot)
+
+	if _, err := os.Stat(dotDir); errors.Is(err, os.ErrNotExist) {
+		// Don't try to walk or an error occurs. It's possible to want
+		// to deploy a dot without there being a dot folder.
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	files := make([]string, 0)
 
 	walkFunc := func(path string, d fs.DirEntry, err error) error {
 		if err != nil {


### PR DESCRIPTION
Errors no longer occur when attempting to deploy with method none and there is no directory. Shallow also no longer creates a link to a non-existent directory if there are no rules for the dot.